### PR TITLE
Patch: Update image version for openproblems/base_* images

### DIFF
--- a/src/control_methods/ground_truth/config.vsh.yaml
+++ b/src/control_methods/ground_truth/config.vsh.yaml
@@ -11,7 +11,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran: [ arrow, dplyr ]

--- a/src/control_methods/mean_across_celltypes/config.vsh.yaml
+++ b/src/control_methods/mean_across_celltypes/config.vsh.yaml
@@ -10,7 +10,7 @@ resources:
   - path: ../../utils/anndata_to_dataframe.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages: [ fastparquet ]

--- a/src/control_methods/mean_across_compounds/config.vsh.yaml
+++ b/src/control_methods/mean_across_compounds/config.vsh.yaml
@@ -10,7 +10,7 @@ resources:
   - path: ../../utils/anndata_to_dataframe.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages: [ fastparquet ]

--- a/src/control_methods/mean_outcome/config.vsh.yaml
+++ b/src/control_methods/mean_outcome/config.vsh.yaml
@@ -10,7 +10,7 @@ resources:
   - path: ../../utils/anndata_to_dataframe.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages: [ fastparquet ]

--- a/src/control_methods/sample/config.vsh.yaml
+++ b/src/control_methods/sample/config.vsh.yaml
@@ -11,7 +11,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran: [ arrow, dplyr ]

--- a/src/control_methods/zeros/config.vsh.yaml
+++ b/src/control_methods/zeros/config.vsh.yaml
@@ -9,7 +9,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages: [ fastparquet ]

--- a/src/methods/jn_ap_op2/config.vsh.yaml
+++ b/src/methods/jn_ap_op2/config.vsh.yaml
@@ -32,7 +32,7 @@ resources:
   - path: helper.py
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     setup:
       - type: python
         packages: 

--- a/src/methods/lgc_ensemble_direct/config.vsh.yaml
+++ b/src/methods/lgc_ensemble_direct/config.vsh.yaml
@@ -55,7 +55,7 @@ resources:
     
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     setup:
       - type: python
         packages:

--- a/src/methods/lgc_ensemble_predict/config.vsh.yaml
+++ b/src/methods/lgc_ensemble_predict/config.vsh.yaml
@@ -33,7 +33,7 @@ resources:
     
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     setup:
       - type: python
         packages:

--- a/src/methods/lgc_ensemble_prepare/config.vsh.yaml
+++ b/src/methods/lgc_ensemble_prepare/config.vsh.yaml
@@ -56,7 +56,7 @@ resources:
     
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     setup:
       - type: python
         packages:

--- a/src/methods/lgc_ensemble_train/config.vsh.yaml
+++ b/src/methods/lgc_ensemble_train/config.vsh.yaml
@@ -46,7 +46,7 @@ resources:
     
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     setup:
       - type: python
         packages:

--- a/src/methods/nn_retraining_with_pseudolabels/config.vsh.yaml
+++ b/src/methods/nn_retraining_with_pseudolabels/config.vsh.yaml
@@ -40,7 +40,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_tensorflow_nvidia:1.0.0
+    image: openproblems/base_tensorflow_nvidia:1
     setup:
       - type: python
         packages: 

--- a/src/methods/pyboost/config.vsh.yaml
+++ b/src/methods/pyboost/config.vsh.yaml
@@ -39,7 +39,7 @@ resources:
   - path: ../../utils/anndata_to_dataframe.py
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     setup:
       - type: python
         packages:

--- a/src/methods/scape/config.vsh.yaml
+++ b/src/methods/scape/config.vsh.yaml
@@ -63,7 +63,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_tensorflow_nvidia:1.0.0
+    image: openproblems/base_tensorflow_nvidia:1
     setup:
       - type: python
         packages:

--- a/src/methods/transformer_ensemble/config.vsh.yaml
+++ b/src/methods/transformer_ensemble/config.vsh.yaml
@@ -47,7 +47,7 @@ resources:
   - path: train.py
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     setup:
       - type: python
         packages:

--- a/src/metrics/mean_rowwise_correlation/config.vsh.yaml
+++ b/src/metrics/mean_rowwise_correlation/config.vsh.yaml
@@ -80,7 +80,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         packages: proxyC

--- a/src/metrics/mean_rowwise_error/config.vsh.yaml
+++ b/src/metrics/mean_rowwise_error/config.vsh.yaml
@@ -55,7 +55,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         packages: proxyC

--- a/src/process_dataset/add_uns_metadata/config.vsh.yaml
+++ b/src/process_dataset/add_uns_metadata/config.vsh.yaml
@@ -51,7 +51,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/process_dataset/bootstrap/config.vsh.yaml
+++ b/src/process_dataset/bootstrap/config.vsh.yaml
@@ -54,7 +54,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/process_dataset/compute_pseudobulk/config.vsh.yaml
+++ b/src/process_dataset/compute_pseudobulk/config.vsh.yaml
@@ -23,7 +23,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages: [ pyarrow ]

--- a/src/process_dataset/convert_h5ad_to_parquet/config.vsh.yaml
+++ b/src/process_dataset/convert_h5ad_to_parquet/config.vsh.yaml
@@ -39,7 +39,7 @@ resources:
   - path: ../../utils/anndata_to_dataframe.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages: [ fastparquet, pandas ]

--- a/src/process_dataset/convert_kaggle_h5ad_to_parquet/config.vsh.yaml
+++ b/src/process_dataset/convert_kaggle_h5ad_to_parquet/config.vsh.yaml
@@ -77,7 +77,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages: [ fastparquet, pandas ]

--- a/src/process_dataset/filter_obs/config.vsh.yaml
+++ b/src/process_dataset/filter_obs/config.vsh.yaml
@@ -23,7 +23,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran: [ dplyr, tidyr, purrr, tibble ]

--- a/src/process_dataset/filter_vars/config.vsh.yaml
+++ b/src/process_dataset/filter_vars/config.vsh.yaml
@@ -23,7 +23,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran: [ edgeR, limma, dplyr, tidyr, purrr, tibble ]

--- a/src/process_dataset/generate_id_map/config.vsh.yaml
+++ b/src/process_dataset/generate_id_map/config.vsh.yaml
@@ -23,7 +23,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/process_dataset/run_limma/config.vsh.yaml
+++ b/src/process_dataset/run_limma/config.vsh.yaml
@@ -45,7 +45,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         bioc: [ edgeR, limma, dplyr, tidyr, purrr, tibble, furrr, future ]

--- a/src/process_dataset/split_sc/config.vsh.yaml
+++ b/src/process_dataset/split_sc/config.vsh.yaml
@@ -33,7 +33,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages: [ anndata, numpy, pandas ]


### PR DESCRIPTION
This PR updates the image version from :1.0.0 to :1 for `openproblems/base_*` images.